### PR TITLE
Relaxed the requirement regarding atomic override of destination registers for LD to allow more implementation options

### DIFF
--- a/zilsd.adoc
+++ b/zilsd.adoc
@@ -38,11 +38,16 @@ In this case, these instruction are guaranteed to not raise an address-misaligne
 Even if naturally aligned, the memory access might not be performed atomically.
 
 If the effective address is a multiple of 4, then each word access is required to be performed atomically.
-The LD instruction must however write the loaded data to the pair of destination registers atomically to ensure fault handling is possible.
+
+To ensure fault handling is possible for the load instructions, it must be ensured that the register which is the source of the base address is not overwritten before the entire operation is complete.
+This affects x2 for the stack pointer relative instruction and rs1 otherwise.
+To guarantee this, if one of the destination registers of the pair is the source register containing the base, it must not be written to before the other register is the pair has been written.
 
 [NOTE]
 ====
-If an implementation performs a doubleword access atomically, the mentioned atomicity requirements are inherently fulfilled.
+If an implementation performs a doubleword access atomically and the register file allows writing the pair, the mentioned atomicity requirements are inherently fulfilled.
+Otherwise, an implementation either needs to delay the writeback until the write can be performed atomically,
+or order sequential writes to the registers to ensure the requirement above is satisfied.
 ====
 
 [[zclsd, Zclsd]]

--- a/zilsd.adoc
+++ b/zilsd.adoc
@@ -45,7 +45,8 @@ To guarantee this, if one of the destination registers of the pair is the source
 
 [NOTE]
 ====
-If an implementation performs a doubleword access atomically and the register file allows writing the pair, the mentioned atomicity requirements are inherently fulfilled.
+If an implementation performs a doubleword load access atomically and the register file implements writeback for even/odd register pairs,
+the mentioned atomicity requirements are inherently fulfilled.
 Otherwise, an implementation either needs to delay the writeback until the write can be performed atomically,
 or order sequential writes to the registers to ensure the requirement above is satisfied.
 ====

--- a/zilsd.adoc
+++ b/zilsd.adoc
@@ -41,7 +41,7 @@ If the effective address is a multiple of 4, then each word access is required t
 
 To ensure fault handling is possible for the load instructions, it must be ensured that the register which is the source of the base address is not overwritten before the entire operation is complete.
 This affects x2 for the stack pointer relative instruction and rs1 otherwise.
-To guarantee this, if one of the destination registers of the pair is the source register containing the base, it must not be written to before the other register is the pair has been written.
+To guarantee this, if one of the destination registers of the pair is the source register containing the base, it must not be written to before the other register in the pair has been written.
 
 [NOTE]
 ====


### PR DESCRIPTION
The previous definition prevented some implementations for low end MCUs, which may be desirable. Particularly, for devices with a 32b data interface and a 2R1W register file, atomic write back to the pair would only be possible by disabling interrupts during the operation. The requirement for atomic writeback was unnecessarily restrictive. This change relaxed the requirement to the minimum needed to ensure fault handling is possible. The change is backwards compatible as any implementation complying to the more restrictive requirement complies to the updated one